### PR TITLE
(DO NOT MERGE) Switch tracking to full Url tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-lib/
 node_modules/
 yarn-debug.log*
 yarn-error.log*

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.trackEvent = exports.trackUser = exports.trackPage = exports.initAnalytics = exports.default = undefined;
+
+var _withAnalytics = require('./withAnalytics');
+
+var _withAnalytics2 = _interopRequireDefault(_withAnalytics);
+
+var _utils = require('./utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = _withAnalytics2.default;
+exports.initAnalytics = _utils.initAnalytics;
+exports.trackPage = _utils.trackPage;
+exports.trackUser = _utils.trackUser;
+exports.trackEvent = _utils.trackEvent;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,38 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.trackEvent = exports.trackUser = exports.trackPage = exports.initAnalytics = undefined;
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _reactGa = require('react-ga');
+
+var _reactGa2 = _interopRequireDefault(_reactGa);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var initAnalytics = exports.initAnalytics = function initAnalytics(trackingId) {
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  return _reactGa2.default.initialize(trackingId, opts);
+};
+
+var trackPage = exports.trackPage = function trackPage(page) {
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var trackerNames = arguments[2];
+  var title = arguments[3];
+
+  _reactGa2.default.set(_extends({ page: page }, opts));
+  _reactGa2.default.pageview(page, trackerNames, title);
+};
+
+var trackUser = exports.trackUser = function trackUser(userId) {
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  return _reactGa2.default.set(_extends({ userId: userId }, opts));
+};
+
+var trackEvent = exports.trackEvent = function trackEvent(category, action, label) {
+  var opts = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+  return _reactGa2.default.event(_extends({ category: category, action: action, label: label }, opts));
+};

--- a/lib/withAnalytics.js
+++ b/lib/withAnalytics.js
@@ -1,0 +1,78 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _utils = require('./utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var withAnalyticsCreator = function withAnalyticsCreator(Component) {
+  var _class, _temp2;
+
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  return _temp2 = _class = function (_React$PureComponent) {
+    _inherits(WithAnalytics, _React$PureComponent);
+
+    function WithAnalytics() {
+      var _ref;
+
+      var _temp, _this, _ret;
+
+      _classCallCheck(this, WithAnalytics);
+
+      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = WithAnalytics.__proto__ || Object.getPrototypeOf(WithAnalytics)).call.apply(_ref, [this].concat(args))), _this), _this.baseRoute = options.basename || '', _temp), _possibleConstructorReturn(_this, _ret);
+    }
+
+    _createClass(WithAnalytics, [{
+      key: 'componentDidMount',
+      value: function componentDidMount() {
+        var page = this.props.location.pathname;
+        (0, _utils.trackPage)('' + this.baseRoute + page);
+      }
+    }, {
+      key: 'componentWillReceiveProps',
+      value: function componentWillReceiveProps(nextProps) {
+        var currentPage = this.props.location.pathname;
+        var nextPage = nextProps.location.pathname;
+        if (currentPage !== nextPage) {
+          (0, _utils.trackPage)('' + this.baseRoute + page);
+        }
+      }
+    }, {
+      key: 'render',
+      value: function render() {
+        return _react2.default.createElement(Component, this.props);
+      }
+    }]);
+
+    return WithAnalytics;
+  }(_react2.default.PureComponent), _class.propTypes = {
+    location: _propTypes2.default.shape({
+      pathname: _propTypes2.default.string.isRequired
+    }).isRequired
+  }, _temp2;
+};
+
+exports.default = withAnalyticsCreator;

--- a/lib/withAnalytics.js
+++ b/lib/withAnalytics.js
@@ -24,55 +24,57 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var withAnalyticsCreator = function withAnalyticsCreator(Component) {
-  var _class, _temp2;
+var withAnalyticsCreator = function withAnalyticsCreator() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  return function (Component) {
+    var _class, _temp2;
 
-  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  return _temp2 = _class = function (_React$PureComponent) {
-    _inherits(WithAnalytics, _React$PureComponent);
+    return _temp2 = _class = function (_React$PureComponent) {
+      _inherits(WithAnalytics, _React$PureComponent);
 
-    function WithAnalytics() {
-      var _ref;
+      function WithAnalytics() {
+        var _ref;
 
-      var _temp, _this, _ret;
+        var _temp, _this, _ret;
 
-      _classCallCheck(this, WithAnalytics);
+        _classCallCheck(this, WithAnalytics);
 
-      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-        args[_key] = arguments[_key];
+        for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+          args[_key] = arguments[_key];
+        }
+
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = WithAnalytics.__proto__ || Object.getPrototypeOf(WithAnalytics)).call.apply(_ref, [this].concat(args))), _this), _this.baseRoute = options.basename || '', _temp), _possibleConstructorReturn(_this, _ret);
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = WithAnalytics.__proto__ || Object.getPrototypeOf(WithAnalytics)).call.apply(_ref, [this].concat(args))), _this), _this.baseRoute = options.basename || '', _temp), _possibleConstructorReturn(_this, _ret);
-    }
-
-    _createClass(WithAnalytics, [{
-      key: 'componentDidMount',
-      value: function componentDidMount() {
-        var page = this.props.location.pathname;
-        (0, _utils.trackPage)('' + this.baseRoute + page);
-      }
-    }, {
-      key: 'componentWillReceiveProps',
-      value: function componentWillReceiveProps(nextProps) {
-        var currentPage = this.props.location.pathname;
-        var nextPage = nextProps.location.pathname;
-        if (currentPage !== nextPage) {
+      _createClass(WithAnalytics, [{
+        key: 'componentDidMount',
+        value: function componentDidMount() {
+          var page = this.props.location.pathname;
           (0, _utils.trackPage)('' + this.baseRoute + page);
         }
-      }
-    }, {
-      key: 'render',
-      value: function render() {
-        return _react2.default.createElement(Component, this.props);
-      }
-    }]);
+      }, {
+        key: 'componentWillReceiveProps',
+        value: function componentWillReceiveProps(nextProps) {
+          var currentPage = this.props.location.pathname;
+          var nextPage = nextProps.location.pathname;
+          if (currentPage !== nextPage) {
+            (0, _utils.trackPage)('' + this.baseRoute + page);
+          }
+        }
+      }, {
+        key: 'render',
+        value: function render() {
+          return _react2.default.createElement(Component, this.props);
+        }
+      }]);
 
-    return WithAnalytics;
-  }(_react2.default.PureComponent), _class.propTypes = {
-    location: _propTypes2.default.shape({
-      pathname: _propTypes2.default.string.isRequired
-    }).isRequired
-  }, _temp2;
+      return WithAnalytics;
+    }(_react2.default.PureComponent), _class.propTypes = {
+      location: _propTypes2.default.shape({
+        pathname: _propTypes2.default.string.isRequired
+      }).isRequired
+    }, _temp2;
+  };
 };
 
 exports.default = withAnalyticsCreator;

--- a/lib/withAnalytics.js
+++ b/lib/withAnalytics.js
@@ -58,7 +58,7 @@ var withAnalyticsCreator = function withAnalyticsCreator() {
           var currentPage = this.props.location.pathname;
           var nextPage = nextProps.location.pathname;
           if (currentPage !== nextPage) {
-            (0, _utils.trackPage)('' + this.baseRoute + page);
+            (0, _utils.trackPage)('' + this.baseRoute + nextPage);
           }
         }
       }, {

--- a/lib/withAnalytics.js
+++ b/lib/withAnalytics.js
@@ -49,14 +49,14 @@ var withAnalyticsCreator = function withAnalyticsCreator() {
       _createClass(WithAnalytics, [{
         key: 'componentDidMount',
         value: function componentDidMount() {
-          var page = this.props.location.pathname;
+          var page = this.props.location.url;
           (0, _utils.trackPage)('' + this.baseRoute + page);
         }
       }, {
         key: 'componentWillReceiveProps',
         value: function componentWillReceiveProps(nextProps) {
-          var currentPage = this.props.location.pathname;
-          var nextPage = nextProps.location.pathname;
+          var currentPage = this.props.location.url;
+          var nextPage = nextProps.location.url;
           if (currentPage !== nextPage) {
             (0, _utils.trackPage)('' + this.baseRoute + nextPage);
           }
@@ -71,7 +71,7 @@ var withAnalyticsCreator = function withAnalyticsCreator() {
       return WithAnalytics;
     }(_react2.default.PureComponent), _class.propTypes = {
       location: _propTypes2.default.shape({
-        pathname: _propTypes2.default.string.isRequired
+        url: _propTypes2.default.string.isRequired
       }).isRequired
     }, _temp2;
   };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "license": "MIT",
   "name": "react-with-analytics",
   "description": "Google Analytics for React apps with ease.",
-  "version": "0.0.6",
+  "version": "0.0.7,
   "main": "lib/index.js",
   "dependencies": {
     "prop-types": "15.6.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "license": "MIT",
   "name": "react-with-analytics",
   "description": "Google Analytics for React apps with ease.",
-  "version": "0.0.7,
+  "version": "0.0.7",
   "main": "lib/index.js",
   "dependencies": {
     "prop-types": "15.6.2"

--- a/package.json
+++ b/package.json
@@ -2,12 +2,8 @@
   "license": "MIT",
   "name": "react-with-analytics",
   "description": "Google Analytics for React apps with ease.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "lib/index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/sonaye/react-with-analytics.git"
-  },
   "dependencies": {
     "prop-types": "15.6.2"
   },

--- a/src/withAnalytics.js
+++ b/src/withAnalytics.js
@@ -23,7 +23,7 @@ const withAnalyticsCreator = (options = {})  => Component =>
       const currentPage = this.props.location.pathname;
       const nextPage = nextProps.location.pathname;
       if (currentPage !== nextPage) { 
-        trackPage(`${this.baseRoute}${page}`);
+        trackPage(`${this.baseRoute}${nextPage}`);
       }
     }
 

--- a/src/withAnalytics.js
+++ b/src/withAnalytics.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { trackPage } from './utils';
 
-const withAnalyticsCreator = (Component, options = {}) =>
+const withAnalyticsCreator = (options = {})  => Component =>
   class WithAnalytics extends React.PureComponent {
     static propTypes = {
       location: PropTypes.shape({

--- a/src/withAnalytics.js
+++ b/src/withAnalytics.js
@@ -4,26 +4,32 @@ import PropTypes from 'prop-types';
 
 import { trackPage } from './utils';
 
-export default Component =>
+const withAnalyticsCreator = (Component, options = {}) =>
   class WithAnalytics extends React.PureComponent {
     static propTypes = {
       location: PropTypes.shape({
         pathname: PropTypes.string.isRequired
       }).isRequired
     };
-
+    
+    baseRoute = options.basename || '';
+    
     componentDidMount() {
       const page = this.props.location.pathname;
-      trackPage(page);
+      trackPage(`${this.baseRoute}${page}`);
     }
 
     componentWillReceiveProps(nextProps) {
       const currentPage = this.props.location.pathname;
       const nextPage = nextProps.location.pathname;
-      if (currentPage !== nextPage) trackPage(nextPage);
+      if (currentPage !== nextPage) { 
+        trackPage(`${this.baseRoute}${page}`);
+      }
     }
 
     render() {
       return <Component {...this.props} />;
     }
   };
+
+  export default withAnalyticsCreator;

--- a/src/withAnalytics.js
+++ b/src/withAnalytics.js
@@ -8,20 +8,20 @@ const withAnalyticsCreator = (options = {})  => Component =>
   class WithAnalytics extends React.PureComponent {
     static propTypes = {
       location: PropTypes.shape({
-        pathname: PropTypes.string.isRequired
+        url: PropTypes.string.isRequired
       }).isRequired
     };
     
     baseRoute = options.basename || '';
     
     componentDidMount() {
-      const page = this.props.location.pathname;
+      const page = this.props.location.url;
       trackPage(`${this.baseRoute}${page}`);
     }
 
     componentWillReceiveProps(nextProps) {
-      const currentPage = this.props.location.pathname;
-      const nextPage = nextProps.location.pathname;
+      const currentPage = this.props.location.url;
+      const nextPage = nextProps.location.url;
       if (currentPage !== nextPage) { 
         trackPage(`${this.baseRoute}${nextPage}`);
       }


### PR DESCRIPTION
This feature:
* Allowing tracking for full url (including query parameters)

Currently not the most elegant solution, and technically breaking.  I would prefer to enhance this configuration setup to include "withQueryParam" option (that could even default to `true`) that would handle the option of tracking query params. 

Also, some talk of whether query param tracking is useful/duplicate of mixpanel or other services.